### PR TITLE
27 add start and finish functionality

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -46,6 +46,6 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:title, :details)
+    params.require(:task).permit(:title, :details, :started_at, :finished_at)
   end
 end

--- a/app/helpers/task_helper.rb
+++ b/app/helpers/task_helper.rb
@@ -1,0 +1,5 @@
+module TaskHelper
+  def has_value?(task_value)
+    task_value.nil? ? 'Not yet' : task_value
+  end
+end

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -11,7 +11,15 @@
           <div class="card-text trix-content">
             <%= task.details %>
           </div>
-          <%= link_to 'Delete', task_path(task), method: :delete, data: {confirm: "Are you sure?"}, class:'btn btn-danger mt-2'%>
+          <div class="card-footer mb-3">
+            <small class="text-muted">
+              <b>Started at: </b><%= has_value?(task.started_at) %> |
+              <b>Finished at: </b> <%= has_value?(task.finished_at) %>
+            </small>
+          </div>
+
+          <%= link_to 'Delete', task_path(task), method: :delete, data: {confirm: "Are you sure?"}, class:'btn btn-danger'%>
+          <%= link_to 'Show', task_path(task), class:'btn btn-outline-info'%>
         </div>
       </div>
     </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,22 +1,43 @@
 <div class="card mt-4 mb-2">
-  <div class="card-header">
-    Anonymous
+  <div class="card-header ">
+    <b>Anonymous</b>
+    <small class="text-muted d-flex">
+        <div class= "p-2">
+          <b>Started at: </b><%= has_value?(@task.started_at) %>
+        </div>
+        <div class= "p-2">
+          <b>Finished at: </b> <%= has_value?(@task.finished_at) %>
+        </div>
+    </small>
   </div>
   <div class="card-body">
     <h5 class="card-title"><%= @task.title %></h5>
     <div class="card-text trix-content mb-2">
       <%= @task.details %>
     </div>
-    <%= link_to 'Edit', edit_task_path(@task), class:'btn btn-outline-info'%>
-    <%= link_to 'Delete', task_path(@task), method: :delete, data: {confirm: "Are you sure?"}, class:'btn btn-outline-danger'%>
-    <%= link_to 'Start Task', '#', class:'btn btn-outline-primary'%>
+    <%= link_to 'Edit', edit_task_path(@task),
+      class:'btn btn-outline-info' %>
+    <%= link_to 'Delete', task_path(@task),
+      method: :delete, data: { confirm: "Are you sure?" },
+      class:'btn btn-outline-danger' %>
+    <% if @task.started_at.nil? %>
+      <%= link_to 'Start Task',
+        task_path(@task, task: { started_at: Time.now }),
+        method: :put, data: { confirm: "Are you sure?" },
+        class:'btn btn-outline-primary'%>
+    <% else %>
+      <%= link_to 'Finish Task',
+        task_path(@task, task: { finished_at: Time.now }),
+        method: :put, data: { confirm: "Are you sure?" },
+        class:'btn btn-outline-info'%>
+    <% end %>
   </div>
   <div class="card-footer">
-      <small class="text-muted">
-        <b>Created at: </b><%= @task.created_at%> |
-        <b>Edited at: </b> <%= @task.updated_at%>
-      </small>
-    </div>
+    <small class="text-muted">
+      <b>Created at: </b><%= @task.created_at%> |
+      <b>Edited at: </b> <%= @task.updated_at%>
+    </small>
+  </div>
 </div>
 
 <%= link_to 'Go back', tasks_path%>

--- a/db/migrate/20220927172512_add_time_to_tasks.rb
+++ b/db/migrate/20220927172512_add_time_to_tasks.rb
@@ -1,0 +1,6 @@
+class AddTimeToTasks < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tasks, :started_at, :datetime
+    add_column :tasks, :finished_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_26_212750) do
+ActiveRecord::Schema.define(version: 2022_09_27_172512) do
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
@@ -54,6 +54,8 @@ ActiveRecord::Schema.define(version: 2022_09_26_212750) do
     t.string "title"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "started_at"
+    t.datetime "finished_at"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
# Description
- Generated migration for started at and finished at datetime fields
- Added button to save started at time in show
- Added button to save finished at time in show
- Added show button in index
- Added helper to display correctly the started at and finished at times in index and show
 
 # Testing
Go to a task and start the task
Go to the same task and finish the task
Go to index and see the started at and finished at times
Go to show and see the started at and finished at times
 
  ## Screenshots 

### Index view
<img width="1340" alt="Captura de Pantalla 2022-09-27 a la(s) 16 04 13" src="https://user-images.githubusercontent.com/105825809/192635043-98d2f18e-ec51-4df8-be3d-e49a38aa83f0.png">

### Show view
<img width="1728" alt="Captura de Pantalla 2022-09-27 a la(s) 16 04 53" src="https://user-images.githubusercontent.com/105825809/192635130-be1a027a-7100-420c-8ddb-5cf3b6ca9ae5.png">
